### PR TITLE
[R4R] Validator count to be enforced in the smart contracts

### DIFF
--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -30,6 +30,7 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
   // the precision of cross chain value transfer.
   uint256 public constant PRECISION = 1e10;
   uint256 public constant EXPIRE_TIME_SECOND_GAP = 1000;
+  uint256 public constant MAX_NUM_OF_VALIDATORS = 41;
 
   bytes public constant INIT_VALIDATORSET_BYTES = hex"f84580f842f840949fb29aac15b9a4b7f17c3385939b007540f4d791949fb29aac15b9a4b7f17c3385939b007540f4d791949fb29aac15b9a4b7f17c3385939b007540f4d79164";
 
@@ -395,6 +396,9 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
   /*********************** Internal Functions **************************/
 
   function checkValidatorSet(Validator[] memory validatorSet) private pure returns(bool, string memory) {
+    if (validatorSet.length > MAX_NUM_OF_VALIDATORS){
+      return (false, "the number of validators exceed the limit");
+    }
     for (uint i = 0;i<validatorSet.length;i++) {
       for (uint j = 0;j<i;j++) {
         if (validatorSet[i].consensusAddress == validatorSet[j].consensusAddress) {

--- a/contracts/BSCValidatorSet.template
+++ b/contracts/BSCValidatorSet.template
@@ -30,6 +30,7 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
   // the precision of cross chain value transfer.
   uint256 public constant PRECISION = 1e10;
   uint256 public constant EXPIRE_TIME_SECOND_GAP = 1000;
+  uint256 public constant MAX_NUM_OF_VALIDATORS = 41;
 
   bytes public constant INIT_VALIDATORSET_BYTES = hex"{{initValidatorSetBytes}}";
 
@@ -404,6 +405,9 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
   /*********************** Internal Functions **************************/
 
   function checkValidatorSet(Validator[] memory validatorSet) private pure returns(bool, string memory) {
+    if (validatorSet.length > MAX_NUM_OF_VALIDATORS){
+      return (false, "the number of validators exceed the limit");
+    }
     for (uint i = 0;i<validatorSet.length;i++) {
       for (uint j = 0;j<i;j++) {
         if (validatorSet[i].consensusAddress == validatorSet[j].consensusAddress) {

--- a/test/BSCValidatorSet.js
+++ b/test/BSCValidatorSet.js
@@ -496,6 +496,25 @@ contract('BSCValidatorSet', (accounts) => {
   });
 });
 
+contract('BSCValidatorSet', (accounts) => {
+  it('test distribute algorithm with more than 41 validators', async () => {
+    const validatorSetInstance = await BSCValidatorSet.deployed();
+    let relayerAccount = accounts[8];
+
+    let newValidators = [];
+    for (let i = 0; i < 42; i++) {
+      newValidators.push(web3.eth.accounts.create().address)
+    }
+    let packageBytes = validatorUpdateRlpEncode(newValidators,
+        newValidators, newValidators);
+    let tx = await validatorSetInstance.handleSynPackage(STAKE_CHANNEL_ID, packageBytes, {from: relayerAccount});
+    
+    truffleAssert.eventEmitted(tx, "failReasonWithStr", (ev) => {
+      return ev.message === "the number of validators exceed the limit";
+    });
+  });
+});
+
 
 function jailRlpEncode(consensusAddrList,feeAddrList, bscFeeAddrList) {
   let pkg = [];


### PR DESCRIPTION
Currently, the number of BSC validators is not limited in the contracts.  The max intended number of BSC validators is 41. 