### PR TITLE
R4R: update decimals return type to uint8

### DIFF
--- a/contracts/bep20_template/BEP20Token.template
+++ b/contracts/bep20_template/BEP20Token.template
@@ -9,7 +9,7 @@ interface IBEP20 {
   /**
    * @dev Returns the token decimals.
    */
-  function decimals() external view returns (uint256);
+  function decimals() external view returns (uint8);
 
   /**
    * @dev Returns the token symbol.
@@ -368,7 +368,7 @@ contract BEP20Token is Context, IBEP20, Ownable {
   /**
    * @dev Returns the token decimals.
    */
-  function decimals() external view returns (uint256) {
+  function decimals() external view returns (uint8) {
     return _decimals;
   }
 

--- a/contracts/interface/IBEP20.sol
+++ b/contracts/interface/IBEP20.sol
@@ -9,7 +9,7 @@ interface IBEP20 {
     /**
      * @dev Returns the token decimals.
      */
-    function decimals() external view returns (uint256);
+    function decimals() external view returns (uint8);
 
     /**
      * @dev Returns the token symbol.

--- a/contracts/test/ABCToken.sol
+++ b/contracts/test/ABCToken.sol
@@ -37,7 +37,7 @@ contract ABCToken is Context, IBEP20, Ownable {
   /**
    * @dev Returns the token decimals.
    */
-  function decimals() external override view returns (uint256) {
+  function decimals() external override view returns (uint8) {
     return _decimals;
   }
 

--- a/contracts/test/DEFToken.sol
+++ b/contracts/test/DEFToken.sol
@@ -37,7 +37,7 @@ contract DEFToken is Context, IBEP20, Ownable {
   /**
    * @dev Returns the token decimals.
    */
-  function decimals() external override view returns (uint256) {
+  function decimals() external override view returns (uint8) {
     return _decimals;
   }
 

--- a/contracts/test/MaliciousToken.sol
+++ b/contracts/test/MaliciousToken.sol
@@ -37,7 +37,7 @@ contract MaliciousToken is Context, IBEP20, Ownable {
   /**
    * @dev Returns the token decimals.
    */
-  function decimals() external override view returns (uint256) {
+  function decimals() external override view returns (uint8) {
     return _decimals;
   }
 

--- a/contracts/test/MiniToken.sol
+++ b/contracts/test/MiniToken.sol
@@ -37,7 +37,7 @@ contract MiniToken is Context, IBEP20, Ownable {
   /**
    * @dev Returns the token decimals.
    */
-  function decimals() external override view returns (uint256) {
+  function decimals() external override view returns (uint8) {
     return _decimals;
   }
 


### PR DESCRIPTION
Update decimals return type to uint8 in BEP20 interface